### PR TITLE
redo state algorithm

### DIFF
--- a/ports/atmel-samd/common-hal/rotaryio/IncrementalEncoder.h
+++ b/ports/atmel-samd/common-hal/rotaryio/IncrementalEncoder.h
@@ -37,7 +37,8 @@ typedef struct {
     uint8_t pin_b;
     uint8_t eic_channel_a:4;
     uint8_t eic_channel_b:4;
-    uint8_t last_state;
+    uint8_t last_state:4;   // <old A><old B><new A><new B>
+    int8_t quarter_count:4; // count intermediate transitions between detents
     mp_int_t position;
 } rotaryio_incrementalencoder_obj_t;
 


### PR DESCRIPTION
This is a redo of the rotary encoder algorithm. It was inspired by some simpler versions I found last night, like: https://www.mikrocontroller.net/articles/Drehgeber#Dekoder_f.C3.BCr_Drehgeber_mit_wackeligen_Rastpunktenr (not that I can read German; hurray Google Translate)

But I haven't see anyone else do the `quarter_count` business, which I think is an easier way to keep track of the history of the previous states. It's easier to understand than the bigger state tables in  https://github.com/buxtronix/arduino/blob/master/libraries/Rotary/Rotary.cpp.