### PR TITLE
Fix issue with EHCI and dcache

### DIFF
--- a/ports/mimxrt10xx/Makefile
+++ b/ports/mimxrt10xx/Makefile
@@ -201,12 +201,19 @@ include $(TOP)/py/mkrules.mk
 print-%:
 	@echo $* = $($*)
 
-ifeq ($(CHIP_FAMILY), MIMXRT1062)
-PYOCD_TARGET = mimxrt1060
-endif
+# Flash using jlink
+define jlink_script
+halt
+loadfile $^
+r
+go
+exit
+endef
+export jlink_script
 
-# Flash using pyocd
-PYOCD_OPTION ?=
-flash: $(BUILD)/firmware.hex
-	pyocd flash -t $(PYOCD_TARGET) $(PYOCD_OPTION) $<
-	pyocd reset -t $(PYOCD_TARGET)
+JLINKEXE = JLinkExe
+flash-jlink: $(BUILD)/firmware.elf
+	@echo "$$jlink_script" > $(BUILD)/firmware.jlink
+	$(JLINKEXE) -device $(CHIP_FAMILY)xxx5A -if swd -JTAGConf -1,-1 -speed auto -CommandFile $(BUILD)/firmware.jlink
+
+flash: flash-jlink

--- a/ports/mimxrt10xx/boards/imxrt1060_evk/mpconfigboard.h
+++ b/ports/mimxrt10xx/boards/imxrt1060_evk/mpconfigboard.h
@@ -21,5 +21,5 @@
 
 // Put host on the first USB so that right angle OTG adapters can fit. This is
 // the right port when looking at the board.
-#define CIRCUITPY_USB_DEVICE_INSTANCE 1
-#define CIRCUITPY_USB_HOST_INSTANCE 0
+#define CIRCUITPY_USB_DEVICE_INSTANCE 0
+#define CIRCUITPY_USB_HOST_INSTANCE 1


### PR DESCRIPTION
- bump up tinyusb which include lots of fixes as well as dache support for imxrt. Previously, ehci data and application buffer is placed randomly and mostly landed in ocram, which is a cached region.
  - https://github.com/hathach/tinyusb/pull/2058
  - https://github.com/hathach/tinyusb/pull/2061
- Also add flash/flash-jlink for quickly testing out the firmware. On-board openSDAv2 DAP can be programmed to JLINK firmware using lpcscrypt which is 20x faster
- Change the usb instance for usb host and otg to match 1060 evk manual. It is probably the default jumper setting on the board. @tannewt let me know if you want to revert this.

Tested and is able to enumerate an logitech usb dongle + another msc device.

![image](https://github.com/hathach/tinyusb/assets/249515/0acce45b-b791-46ba-8117-877f2ba35c3a)
